### PR TITLE
Expand CI/CD pipeline to include build, test, and deploy stages

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -10,11 +10,23 @@ jobs:
         with:
           node-version: '14'
       - run: npm install
+      - run: npm run build
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: npm install
       - run: npm test
 
   deploy:
     runs-on: ubuntu-latest
-    needs: build
+    needs: test
     steps:
       - uses: actions/checkout@v2
       - name: Set up deployment environment

--- a/README.md
+++ b/README.md
@@ -60,5 +60,11 @@ We use GitHub Actions for continuous integration (CI) in this repository. The CI
 1. **Checkout code**: Uses the `actions/checkout@v2` action to checkout the repository code.
 2. **Set up Node.js**: Uses the `actions/setup-node@v2` action to set up Node.js version 14.
 3. **Install dependencies**: Runs `npm install` to install the necessary npm dependencies.
-4. **Run tests**: Runs `npm test` to execute the test suite.
-5. **Deploy application**: Runs the deployment steps to deploy the application after the tests pass.
+4. **Build application**: Runs `npm run build` to build the application.
+5. **Run tests**: Runs `npm test` to execute the test suite.
+6. **Deploy application**: Runs the deployment steps to deploy the application after the tests pass.
+
+### Deployment Steps
+
+1. **Set up deployment environment**: Prepares the environment for deployment.
+2. **Deploy application**: Executes the deployment process to make the application live.


### PR DESCRIPTION
Expand the CI/CD pipeline to include build, test, and deploy stages.

* **README.md**
  - Add a build step to run `npm run build`.
  - Add a deployment steps section to describe the deployment process.

* **.github/workflows/ci-pipeline.yml**
  - Add a build job to run `npm run build`.
  - Add a test job that depends on the build job.
  - Update the deploy job to depend on the test job.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/NexusDevops?shareId=b181d28f-8855-4a4a-9343-fc067ac3f79e).